### PR TITLE
fix #4: Added input method/keyboard icon to system tray

### DIFF
--- a/anomshell/config/quickshell/bar/modules/Tray.qml
+++ b/anomshell/config/quickshell/bar/modules/Tray.qml
@@ -77,6 +77,7 @@ Item {
         if (_hasAny(text, ["clipboard"])) return "󰅌"
         if (_hasAny(text, ["calendar"])) return "󰃭"
         if (_hasAny(text, ["notes", "note"])) return "󱞎"
+        if (_hasAny(text, ["input method", "input-keyboard"])) return "󰧹"
         return ""
     }
 


### PR DESCRIPTION
System tray was missing the input method/keyboard icon resulting in a missing texture icon.
Fix #4 