### PR TITLE
fix #6: Improve helper script to kill conflicting (default) processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ anomshell/
 ├── local/
 │   └── bin/
 │       ├── qs.sh
-│       └── wb-kill.sh
+│       └── kill_omarchy_conflicts.sh.sh
 │
 ├── LICENSE
 └── README.md
@@ -261,7 +261,7 @@ Open `config/hypr/bindings.conf`, copy the Quickshell binds, and **manually past
 ```bash
 cp local/bin/* ~/.local/bin/
 chmod +x ~/.local/bin/qs.sh
-chmod +x ~/.local/bin/wb-kill.sh
+chmod +x ~/.local/bin/kill_omarchy_conflicts.sh.sh
 ```
 
 ### 7 — Start Quickshell

--- a/anomshell/local/bin/kill_omarchy_conflicts.sh
+++ b/anomshell/local/bin/kill_omarchy_conflicts.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+conflicting_processes=(
+    "waybar"
+    "mako"
+)
+
+while true; do
+    still_running=0
+
+    for proc in "${conflicting_processes[@]}"; do
+        if pgrep -x "$proc" > /dev/null; then
+            pkill -x "$proc"
+            still_running=1
+        fi
+    done
+
+    if [[ "$still_running" -eq 0 ]]; then
+        exit 0
+    fi
+    sleep 0.2
+done

--- a/anomshell/local/bin/wb-kill.sh
+++ b/anomshell/local/bin/wb-kill.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-while true; do
-    if pgrep -x waybar > /dev/null; then
-        pkill -x waybar
-        exit 0
-    fi
-    sleep 0.2
-done


### PR DESCRIPTION
Made wb-kill.sh a bit more general.
I don't like that much this double loop we can think of a better solution later on (unless you have suggestions now).